### PR TITLE
Support ranges with an inclusive max version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
         "pretest": "npm run build",
         "test": "jenkins-mocha tests/unit --recursive --compilers js:babel-register"
     },
-    "version": "1.3.1"
+    "version": "1.4.0"
 }

--- a/src/semver-intersect.js
+++ b/src/semver-intersect.js
@@ -19,6 +19,11 @@ function createShorthand (range) {
         return min;
     }
 
+    // Stable range with an inclusive max version
+    if (range.includes('<=')) {
+        return `${min} - ${max}`;
+    }
+
     // Special handling for major version 0
     if (semver.major(min) === 0 && semver.major(max) === 0) {
         // ^0.0.5

--- a/tests/unit/semver-intersect.js
+++ b/tests/unit/semver-intersect.js
@@ -59,6 +59,10 @@ describe('createShorthand', () => {
         const result = createShorthand('>=0.0.0 <0.0.1');
         expect(result).to.equal('^0.0.0');
     });
+    it('should simplify a range within the same major version', () => {
+        const result = createShorthand('>=1.0.0 <=1.5.3');
+        expect(result).to.equal('1.0.0 - 1.5.3');
+    });
     it('should return granular ranges without changes', () => {
         [
             '>4.0.0',
@@ -103,6 +107,10 @@ describe('expandRanges', () => {
     it('should expand the list of ranges into a set of unique individual ranges', () => {
         const result = expandRanges('>=3.0.0 <4.0.0', '>=3.1.0 <4.0.0', '>=3.3.0');
         expect(result).to.deep.equal(['>=3.0.0', '<4.0.0', '>=3.1.0', '>=3.3.0']);
+    });
+    it('should expand a range between two versions', () => {
+        const result = expandRanges('1.0.0 - 1.5.3');
+        expect(result).to.deep.equal(['>=1.0.0', '<=1.5.3']);
     });
 });
 
@@ -182,6 +190,10 @@ describe('intersect', () => {
     it('should throw on incompatible ranges', () => {
         const call = intersect.bind(null, '^4.0.0', '~4.3.0', '^4.4.0');
         expect(call).to.throw('Range >=4.4.0 is not compatible with <4.4.0');
+    });
+    it('should simplify issue 12', () => {
+        const result = intersect('1.0.0 - 1.5.3');
+        expect(result).to.equal('1.0.0 - 1.5.3');
     });
     it('should not cross major bounds', () => {
         expect(intersect.bind(null, '^5.0.0', '^4.0.1'))


### PR DESCRIPTION
@mearns This should fix https://github.com/snyamathi/semver-intersect/issues/12 - thanks for being patient!